### PR TITLE
Add registration month tracking

### DIFF
--- a/include/Controller.php
+++ b/include/Controller.php
@@ -8,6 +8,7 @@ class Controller
     public function __construct()
     {
         $this->crud = new Crud();
+        $this->ensureRegistrationMetaTable();
     }
 
     public function registerUser($data)
@@ -100,6 +101,20 @@ class Controller
             'reg_month' => $regMonth,
         ];
         return $this->crud->create($meta, 'hslhs_kids_registration_meta');
+    }
+
+    private function ensureRegistrationMetaTable()
+    {
+        $sql = "CREATE TABLE IF NOT EXISTS hslhs_kids_registration_meta (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            reg_table ENUM('email','phone') NOT NULL,
+            reg_id INT NOT NULL,
+            reg_month CHAR(3) NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            KEY idx_reg (reg_table, reg_id),
+            KEY idx_month (reg_month)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
+        $this->crud->update($sql, []);
     }
 
 


### PR DESCRIPTION
Introduce a `hslhs_kids_registration_meta` table and ensure its creation to automatically track the registration month for new users.

The task required tracking the month of registration for new users, automatically assigned at registration time. This PR sets up the necessary database structure by creating a dedicated meta table (`hslhs_kids_registration_meta`) to store this information, which will then be populated by the registration logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-8dfae1ed-422c-402a-9074-ee050764189e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8dfae1ed-422c-402a-9074-ee050764189e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

